### PR TITLE
fix: attempted mongoose query if no connection

### DIFF
--- a/apps/backend/src/utils/info.ts
+++ b/apps/backend/src/utils/info.ts
@@ -4,7 +4,7 @@ import WebSocket from "ws"
 import GuildConfigModel, {
 	GuildConfigClass,
 } from "../database/guildconfig"
-import { DocumentType } from "@typegoose/typegoose"
+import { DocumentType, mongoose } from "@typegoose/typegoose"
 import { BeAnObject } from "@typegoose/typegoose/lib/types"
 import { CategoryClass } from "../database/category"
 import { CommunityClass } from "../database/community"
@@ -22,6 +22,8 @@ const WebhookGuildIds = new WeakMap<WebSocket, string[]>()
 let WebhookQueue: MessageEmbed[] = []
 
 async function SendWebhookMessages() {
+	// mongoose isn't connected so no point in sending webhooks, as it will error
+	if (mongoose.connection.readyState !== 1) return
 	const embeds = WebhookQueue.slice(0, 10)
 	if (!embeds[0]) return
 	WebhookQueue = WebhookQueue.slice(10)

--- a/apps/backend/test/prepareTest.ts
+++ b/apps/backend/test/prepareTest.ts
@@ -6,20 +6,20 @@ import { createCategories } from "./utils"
 import backend from "../src/app"
 
 
-let mongod: MongoMemoryReplSet;
+let mongod: MongoMemoryReplSet
 export let testCommunity: CommunityClass
 export let testCategories: CategoryClass[]
 beforeAll(async () => {
 	// ephemeralForTest does not support change streams
-	mongod = await MongoMemoryReplSet.create({ instanceOpts: [{ storageEngine: "wiredTiger" }]})
+	mongod = await MongoMemoryReplSet.create({ instanceOpts: [ { storageEngine: "wiredTiger" } ] })
 	await mongoose.connect(mongod.getUri(), { ignoreUndefined: true })
-
+	
 	// Insert test data
 	testCommunity = await CommunityModel.create({ name: "Test Community", contact: "12345" })
 	testCategories = await CategoryModel.create(createCategories(3))
-
 	await backend.listen(0)
-}, 20e3)
+// TODO: reduce to 20s once MongoMemoryReplSet takes less time to startup
+}, 60e3)
 
 afterAll(async () => {
 	// Watchers throw when disconnecting for some reason


### PR DESCRIPTION
Fix an issue with tests, where a "MongoClient must be connected to perform this operation" error could be thrown by the backend's `apps/backend/src/info.ts` file.