### PR TITLE
fix(backend): fix default reportedTime  constant

### DIFF
--- a/apps/backend/src/routes/reports.controller.ts
+++ b/apps/backend/src/routes/reports.controller.ts
@@ -81,7 +81,7 @@ export default class ReportController {
 					automated: z.boolean().nullish().default(false),
 					reportedTime: z
 						.string()
-						.default(new Date().toISOString())
+						.default(() => new Date().toISOString())
 						.refine(
 							(input) => validator.isISO8601(input),
 							"reportedTime must be a valid ISO8601 date"


### PR DESCRIPTION
Fix default reportedTime on reports being a constant as it would be evaluated only once at server startup, meaning that each report would have the same `reportedTime` by default.