### PR TITLE
Fix permissions for !setapikey, typo in invite URL

### DIFF
--- a/apps/backend/src/routes/discord.controller.ts
+++ b/apps/backend/src/routes/discord.controller.ts
@@ -562,7 +562,7 @@ export default class DiscordController {
 		params.append("scope", BOT_SCOPES.join(" "))
 		params.append("response_type", "code")
 		params.append("redirect_uri", `${ENV.BASE_URL}/discord/oauth/callback`)
-		params.append("permisions", BOT_PERMS.toString())
+		params.append("permissions", BOT_PERMS.toString())
 
 		const url = `https://discord.com/api/oauth2/authorize?${params}`
 

--- a/apps/community-bot/src/commands/config/setapikey.ts
+++ b/apps/community-bot/src/commands/config/setapikey.ts
@@ -8,20 +8,37 @@ const Setapikey = Command({
 	examples: ["setapikey potatoKey"],
 	category: "config",
 	requiresRoles: true,
-	requiredPermissions: ["setConfig"],
+	requiredPermissions: [],
 	requiresApikey: false,
 	fetchFilters: false,
-	run: async ({ client, message, args }) => {
+	run: async ({ client, message, args, guildConfig }) => {
+		message.delete()
+		message.channel.send(
+			"Your message has been removed to prevent unauthorized API access"
+		)
+
+		// if the person doesn't have sufficient permissions, throw an error
+		if (
+			!message.member!.permissions.has("ADMINISTRATOR") &&
+			message.guild.ownerId !== message.author.id &&
+			!message.member!.roles.cache.has(guildConfig.roles.setConfig)
+		) {
+			const role = await message.guild.roles.fetch(
+				guildConfig.roles.setConfig
+			)
+			return message.channel.send(
+				`${client.config.emotes.error} You do not have permission to run this command. ` +
+					`You need to either be the guild owner, have the \`ADMINISTRATOR\` permission, or have the \`${
+						role ? role.name : "unknown role"
+					}\` role.`
+			)
+		}
+
 		const key = args.shift()
 		if (!key)
 			return message.channel.send(
 				"You must provide your API key as a parameter"
 			)
-
-		message.delete()
-		message.channel.send(
-			"Your message has been removed to prevent unauthorized API access"
-		)
 
 		const community = await client.fagc.communities
 			.fetchOwnCommunity({

--- a/apps/community-bot/src/events/guild/messageCreate.ts
+++ b/apps/community-bot/src/events/guild/messageCreate.ts
@@ -83,11 +83,13 @@ export default async (client: FAGCBot, message: Message) => {
 		const roleid = guildConfig.roles[permname] // get the role which has this perm
 		return !message.member?.roles.cache.has(roleid) // if the user does not have the role, return true to keep it in the array
 	})
-	// if the user doesnt have any of the roles and is not the guild owner, return
+	// if the user doesnt have any of the roles, is not the guild owner, or has the ADMINISTRATOR, return
 	if (
 		doesntHaveRoles.length > 0 &&
-		message.guild.ownerId !== message.author.id
+		message.guild.ownerId !== message.author.id &&
+		!message.member!.permissions.has("ADMINISTRATOR")
 	) {
+		// list of roles that are set on the guild config but have since been deleted
 		const nonexistentRoles: string[] = []
 		const roles = doesntHaveRoles
 			.map((permname) => [permname, guildConfig.roles[permname]]) // get the role ID of the perm


### PR DESCRIPTION
Allow the !setapikey command to be used by people with the ADMINISTRATOR permission