### PR TITLE
feat(clientside): required discordChannelId for server

### DIFF
--- a/apps/clientside-bot/package.json
+++ b/apps/clientside-bot/package.json
@@ -26,6 +26,7 @@
 		"@types/faker": "5",
 		"@types/node": "^16.11.12",
 		"better-sqlite3": "^7.5.1",
+		"dayjs": "^1.11.3",
 		"discord-api-types": "0.26.1",
 		"discord.js": "^13.7.0",
 		"dotenv": "^16.0.0",
@@ -37,7 +38,6 @@
 		"sqlite3": "^5.0.2",
 		"typeorm": "^0.2.45",
 		"utility-types": "^3.10.0",
-		"why-is-node-still-running": "^1.0.0",
 		"zod": "^3.11.6"
 	},
 	"devDependencies": {

--- a/apps/clientside-bot/src/base/database.ts
+++ b/apps/clientside-bot/src/base/database.ts
@@ -15,7 +15,7 @@ export const BotConfig = z.object({
 export type BotConfigType = z.infer<typeof BotConfig>
 
 export const FactorioServer = z.object({
-	discordChannelId: z.string().optional(),
+	discordChannelId: z.string(),
 	servername: z
 		.string()
 		.describe("Name of Factorio server that it can be identified with"),

--- a/apps/clientside-bot/src/base/wshandler.ts
+++ b/apps/clientside-bot/src/base/wshandler.ts
@@ -123,7 +123,7 @@ const report = async ({ client, event }: HandlerOpts<"report">) => {
 
 	// ban in guilds that its supposed to
 	guildsToBan.map((guildId) => {
-		const command = client.createBanCommand(event.report, guildId)
+		const command = client.createBanCommand(event.report)
 		if (!command) return // if it is not supposed to do anything in this guild, then it won't do anything
 		client.rcon.rconCommandAll(`/sc ${command}; rcon.print(true)`)
 	})
@@ -175,10 +175,7 @@ const revocation = async ({ client, event }: HandlerOpts<"revocation">) => {
 
 	// unban in guilds that its supposed to
 	guildsToUnban.map((guildId) => {
-		const command = client.createUnbanCommand(
-			event.revocation.playername,
-			guildId
-		)
+		const command = client.createUnbanCommand(event.revocation.playername)
 		if (!command) return // if it is not supposed to do anything in this guild, then it won't do anything
 		client.rcon.rconCommandAll(
 			`/sc game.unban_player("${event.revocation.playername}"); rcon.print(true)`
@@ -200,6 +197,7 @@ const filterObjectChanged = async ({
 	// client.filterObjects.set(event.filterObject.id, event.filterObject) // set the new filter object
 	const allFilters = await client.getAllFilters()
 	const filter = event.filterObject
+	client.filterObject = filter
 
 	const validReports = await client.fagc.reports.list({
 		categoryIds: filter.categoryFilters,
@@ -246,8 +244,7 @@ const disconnected = ({ client }: HandlerOpts<"disconnected">) => {
 }
 // here, we handle stuff since the last connection, such as fetching missed reports, revocations etc.
 const connected = async ({ client }: HandlerOpts<"connected">) => {
-	const lastReceivedDate =
-		client.botConfigs.first()?.lastNotificationProcessed || new Date()
+	const lastReceivedDate = client.botConfig.lastNotificationProcessed
 	const allFilters = await client.getAllFilters()
 
 	// we fetch the missed reports and revocations and act on each of them
@@ -277,7 +274,7 @@ const connected = async ({ client }: HandlerOpts<"connected">) => {
 
 		// ban in guilds that its supposed to
 		guildsToBan.map((guildId) => {
-			const command = client.createBanCommand(report, guildId)
+			const command = client.createBanCommand(report)
 			if (!command) return // if it is not supposed to do anything in this guild, then it won't do anything
 			banCommands.get(guildId)?.push(command)
 		})
@@ -292,10 +289,7 @@ const connected = async ({ client }: HandlerOpts<"connected">) => {
 		})
 		if (!guildsToUnban) return
 		guildsToUnban.map((guildId) => {
-			const command = client.createUnbanCommand(
-				revocation.playername,
-				guildId
-			)
+			const command = client.createUnbanCommand(revocation.playername)
 			if (!command) return // if it is not supposed to do anything in this guild, then it won't do anything
 			unbanCommands.get(guildId)?.push(command)
 		})

--- a/apps/clientside-bot/src/commands/config/setaction.ts
+++ b/apps/clientside-bot/src/commands/config/setaction.ts
@@ -49,8 +49,7 @@ const Setaction: SubCommand = {
 		if (revocation) config.revocationAction = revocation
 		await client.setBotConfig(config)
 
-		const botConfig = await client.getBotConfig(interaction.guildId)
-		if (!botConfig) return interaction.reply("An error occured")
+		const botConfig = client.botConfig
 		return interaction.reply({
 			content: `Report action is ${botConfig.reportAction}. Revocation action is ${botConfig.revocationAction}`,
 		})

--- a/apps/clientside-bot/src/commands/config/syncserver.ts
+++ b/apps/clientside-bot/src/commands/config/syncserver.ts
@@ -1,0 +1,91 @@
+import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
+import { ChannelType } from "discord-api-types"
+import { SubCommand } from "../../base/Commands.js"
+import { splitIntoGroups } from "../../utils/functions.js"
+import FAGCBan from "../../database/FAGCBan.js"
+import PrivateBan from "../../database/PrivateBan.js"
+import dayjs from "dayjs"
+
+const Syncserver: SubCommand = {
+	data: new SlashCommandSubcommandBuilder()
+		.setName("syncserver")
+		.setDescription("Synchronize a server's banlist")
+		.addChannelOption((option) =>
+			option
+				.setName("serverchannel")
+				.setDescription(
+					"Channel paired to the server which to synchronize the banlist of"
+				)
+				.setRequired(true)
+				.addChannelTypes([ChannelType.GuildNews, ChannelType.GuildText])
+		),
+	execute: async ({ client, interaction }) => {
+		const serverchannel = interaction.options.getChannel(
+			"serverchannel",
+			true
+		)
+
+		if (!client.servers.has(serverchannel.guildId))
+			client.servers.set(interaction.guildId, [])
+
+		const server = client.servers
+			.get(interaction.guildId)!
+			.find((server) => server.discordChannelId === serverchannel.id)
+		if (!server)
+			return interaction.reply({
+				content: "The provided channel is not paired to any server",
+				ephemeral: true,
+			})
+
+		await interaction.deferReply()
+
+		await interaction.reply("Compiling banlist for the server...")
+
+		const alreadyBanned = new Set<string>()
+		const banCommands: string[] = []
+
+		// handle private bans first, so that they are not overriden by FAGC bans
+		const privatebans = await client.db.getRepository(PrivateBan).find()
+		for (const ban of privatebans) {
+			const admin = await client.users.fetch(ban.adminId)
+			banCommands.push(
+				`game.ban_player("${ban.playername}", "${ban.reason} by ${
+					admin.username
+				}#${admin.discriminator} on ${dayjs().format(
+					"YYYY-MM-DD HH:mm:ss"
+				)}")`
+			)
+			alreadyBanned.add(ban.playername)
+		}
+
+		const filter = client.filterObject
+		if (filter) {
+			const allFAGCBans = await client.db.getRepository(FAGCBan).find()
+			for (const ban of allFAGCBans) {
+				if (alreadyBanned.has(ban.playername)) continue
+				if (
+					filter.categoryFilters.includes(ban.categoryId) &&
+					filter.communityFilters.includes(ban.communityId)
+				) {
+					const report = await client.fagc.reports.fetchReport({
+						reportId: ban.id,
+					})
+					banCommands.push(client.createBanCommand(report!))
+					alreadyBanned.add(ban.playername)
+				}
+			}
+		}
+
+		await interaction.followUp("Banlist generated, sending to server...")
+
+		await client.rcon.rconCommand("/banlist clear", server.discordChannelId)
+		for (const group of splitIntoGroups(banCommands, 500)) {
+			await client.rcon.rconCommand(
+				"/c ".concat(group.join("; ")),
+				server.discordChannelId
+			)
+		}
+		await interaction.reply("Banlist synchronized with server.")
+	},
+}
+export default Syncserver

--- a/apps/clientside-bot/src/commands/privatebans/create.ts
+++ b/apps/clientside-bot/src/commands/privatebans/create.ts
@@ -2,6 +2,7 @@ import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
 import { z } from "zod"
 import { SubCommand } from "../../base/Commands.js"
 import PrivateBan from "../../database/PrivateBan.js"
+import dayjs from "dayjs"
 
 const Setaction: SubCommand = {
 	data: new SlashCommandSubcommandBuilder()
@@ -46,6 +47,13 @@ const Setaction: SubCommand = {
 			playername: playername,
 			reason: reason,
 		})
+
+		await client.rcon.rconCommandAll(
+			`/ban ${playername} ${reason} by ${interaction.user.username}#${
+				interaction.user.discriminator
+			} on ${dayjs().format("YYYY-MM-DD HH:mm:ss")}`
+		)
+
 		return interaction.reply({
 			content: `Player ${playername} is now banned for ${reason}`,
 		})

--- a/apps/clientside-bot/src/commands/privatebans/remove.ts
+++ b/apps/clientside-bot/src/commands/privatebans/remove.ts
@@ -37,6 +37,8 @@ const Setaction: SubCommand = {
 				ephemeral: true,
 			})
 
+		await client.rcon.rconCommandAll(`/unban ${playername}`)
+
 		return interaction.reply({
 			content: `Player ${playername} has been unbanned by ${interaction.user} for ${reason}`,
 		})

--- a/apps/clientside-bot/src/commands/privatebans/remove.ts
+++ b/apps/clientside-bot/src/commands/privatebans/remove.ts
@@ -2,6 +2,7 @@ import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
 import { z } from "zod"
 import { SubCommand } from "../../base/Commands.js"
 import PrivateBan from "../../database/PrivateBan.js"
+import { hasFAGCBans } from "../../utils/functions.js"
 
 const Setaction: SubCommand = {
 	data: new SlashCommandSubcommandBuilder()
@@ -38,6 +39,24 @@ const Setaction: SubCommand = {
 			})
 
 		await client.rcon.rconCommandAll(`/unban ${playername}`)
+
+		if (client.filterObject) {
+			const hasBan = await hasFAGCBans({
+				playername,
+				filter: client.filterObject,
+				database: client.db,
+			})
+			if (hasBan) {
+				const report = await client.fagc.reports.fetchReport({
+					reportId: hasBan.id,
+				})
+				const bancmd = client.createBanCommand(report!)
+				if (bancmd) await client.rcon.rconCommandAll(bancmd)
+				return interaction.reply({
+					content: `Player ${playername} was unbanned privately, but was banned due to FAGC report ${hasBan.id}`,
+				})
+			}
+		}
 
 		return interaction.reply({
 			content: `Player ${playername} has been unbanned by ${interaction.user} for ${reason}`,

--- a/apps/clientside-bot/src/commands/whitelist/create.ts
+++ b/apps/clientside-bot/src/commands/whitelist/create.ts
@@ -46,6 +46,9 @@ const Setaction: SubCommand = {
 			playername: playername,
 			reason: reason,
 		})
+
+		await client.rcon.rconCommandAll(`/whitelist add ${playername}`)
+
 		return interaction.reply({
 			content: `Player ${playername} is now whitelisted for ${reason}`,
 		})

--- a/apps/clientside-bot/src/commands/whitelist/remove.ts
+++ b/apps/clientside-bot/src/commands/whitelist/remove.ts
@@ -37,6 +37,8 @@ const Setaction: SubCommand = {
 				ephemeral: true,
 			})
 
+		await client.rcon.rconCommandAll(`/whitelist remove ${playername}`)
+
 		return interaction.reply({
 			content: `Player ${playername} has been unwhitelisted by ${interaction.user} for ${reason}`,
 		})

--- a/apps/clientside-bot/src/commands/whitelist/remove.ts
+++ b/apps/clientside-bot/src/commands/whitelist/remove.ts
@@ -2,6 +2,7 @@ import { SlashCommandSubcommandBuilder } from "@discordjs/builders"
 import { z } from "zod"
 import { SubCommand } from "../../base/Commands.js"
 import Whitelist from "../../database/Whitelist.js"
+import { hasFAGCBans } from "../../utils/functions.js"
 
 const Setaction: SubCommand = {
 	data: new SlashCommandSubcommandBuilder()
@@ -38,6 +39,24 @@ const Setaction: SubCommand = {
 			})
 
 		await client.rcon.rconCommandAll(`/whitelist remove ${playername}`)
+
+		if (client.filterObject) {
+			const hasBan = await hasFAGCBans({
+				playername,
+				filter: client.filterObject,
+				database: client.db,
+			})
+			if (hasBan) {
+				const report = await client.fagc.reports.fetchReport({
+					reportId: hasBan.id,
+				})
+				const bancmd = client.createBanCommand(report!)
+				if (bancmd) await client.rcon.rconCommandAll(bancmd)
+				return interaction.reply({
+					content: `Player ${playername} was unwhitelisted, but was banned due to FAGC report ${hasBan.id}`,
+				})
+			}
+		}
 
 		return interaction.reply({
 			content: `Player ${playername} has been unwhitelisted by ${interaction.user} for ${reason}`,

--- a/apps/clientside-bot/src/events/guildDelete.ts
+++ b/apps/clientside-bot/src/events/guildDelete.ts
@@ -4,6 +4,5 @@ import FAGCBot from "../base/FAGCBot.js"
 export default async (client: FAGCBot, [guild]: [Guild]) => {
 	console.log(`Bot has now left guild ${guild.name}, removing their config`)
 
-	client.guildConfigs.delete(guild.id)
 	client.fagc.websocket.removeGuildId(guild.id)
 }

--- a/apps/clientside-bot/src/events/interactionCreate.ts
+++ b/apps/clientside-bot/src/events/interactionCreate.ts
@@ -8,7 +8,7 @@ export default async (client: FAGCBot, [interaction]: [Interaction]) => {
 	const { commandName } = interaction
 	if (!client.commands.has(commandName)) return
 
-	const botConfig = await client.getBotConfig(interaction.guildId)
+	const botConfig = client.botConfig
 
 	// idk but this shouldnt happen
 	if (!interaction.inCachedGuild()) return

--- a/apps/clientside-bot/src/events/ready.ts
+++ b/apps/clientside-bot/src/events/ready.ts
@@ -12,14 +12,6 @@ export default async function handler(client: FAGCBot) {
 	client.guilds.cache.map(async (guild) => {
 		// send info to backend about guilds, get configs through WS
 		client.fagc.websocket.addGuildId(guild.id)
-
-		// create bot configs if they dont exist
-		const config = await client.getBotConfig(guild.id)
-		if (!config)
-			client.setBotConfig({
-				guildId: guild.id,
-				owner: guild.ownerId,
-			})
 	})
 	client.fagc.websocket.addFilterObjectId(ENV.FILTEROBJECTID)
 }

--- a/apps/clientside-bot/src/events/ready.ts
+++ b/apps/clientside-bot/src/events/ready.ts
@@ -7,7 +7,6 @@ export default async function handler(client: FAGCBot) {
 	)
 
 	await client.guilds.fetch()
-	await client.getAllGuildConfigs()
 
 	client.guilds.cache.map(async (guild) => {
 		// send info to backend about guilds, get configs through WS

--- a/apps/clientside-bot/src/utils/functions.ts
+++ b/apps/clientside-bot/src/utils/functions.ts
@@ -486,3 +486,32 @@ export async function handleConnected({
 		toUnban: [...toUnbanPlayers],
 	}
 }
+
+/**
+ * Function to check if a player has valid FAGC reports against them and whether they should be banned for them
+ * @returns False if the player should not be banned, a FAGCBan if the player should be banned
+ */
+export async function hasFAGCBans({
+	playername,
+	filter,
+	database,
+}: {
+	playername: string
+	filter: FilterObject
+	database: Connection
+}): Promise<false | FAGCBan> {
+	const bans = await database.getRepository(FAGCBan).find({
+		playername: playername,
+	})
+	if (bans.length === 0) return false
+
+	// find the first ban that matches the filters and return it
+	for (const ban of bans) {
+		if (!filter.categoryFilters.includes(ban.categoryId)) continue
+		if (!filter.communityFilters.includes(ban.communityId)) continue
+		return ban
+	}
+
+	// if no ban that matches the filters is found, then the player should not be banned
+	return false
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2148,6 +2148,11 @@ dateformat@^4.6.3:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
   integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
+dayjs@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.3.tgz#4754eb694a624057b9ad2224b67b15d552589258"
+  integrity sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
Changed the clientside bot to only have one guild config and one filter object that it listens to in order to prevent complex code for usecases that most likely won't arise.

Resolved #101 with 82a7ba96881653daef367a184ab52fd303ce3234 and 48585f6ac6d17e62006ee76f72b7029173c0591f
Resolved #37 with 0d53b2621c32abface87b7ecba6ffae989544c9e