### PR TITLE
Create actions for FAGC bans and unbans, disable use of /whitelist command

### DIFF
--- a/apps/clientside-bot/src/base/FAGCBot.ts
+++ b/apps/clientside-bot/src/base/FAGCBot.ts
@@ -262,4 +262,34 @@ export default class FAGCBot extends Client {
 			playername: unban.action.playername,
 		})
 	}
+
+	createActionForReport(playername: string) {
+		const action: BaseAction<ServerSyncedBan> = {
+			actionType: "ban",
+			action: {
+				playername: playername,
+				reason: "Some reason",
+				byPlayer: "FAGC User",
+			},
+			receivedAt: new Date(),
+			server: this.servers[0],
+		}
+
+		this.recentServerSyncedActions.push(action)
+	}
+
+	createActionForUnban(playername: string) {
+		const action: BaseAction<ServerSyncedUnban> = {
+			actionType: "unban",
+			action: {
+				playername,
+				reason: "Some reason",
+				byPlayer: "FAGC User",
+			},
+			receivedAt: new Date(),
+			server: this.servers[0],
+		}
+
+		this.recentServerSyncedActions.push(action)
+	}
 }

--- a/apps/clientside-bot/src/commands/privatebans/create.ts
+++ b/apps/clientside-bot/src/commands/privatebans/create.ts
@@ -49,6 +49,7 @@ const Setaction: SubCommand = {
 			reason: reason,
 		})
 
+		client.createActionForReport(playername)
 		await client.rcon.rconCommandAll(
 			`/ban ${playername} ${reason} by ${interaction.user.username}#${
 				interaction.user.discriminator

--- a/apps/clientside-bot/src/commands/privatebans/remove.ts
+++ b/apps/clientside-bot/src/commands/privatebans/remove.ts
@@ -39,22 +39,26 @@ const Setaction: SubCommand = {
 				ephemeral: true,
 			})
 
+		client.createActionForUnban(playername)
 		await client.rcon.rconCommandAll(`/unban ${playername}`)
 
 		if (client.filterObject) {
-			const hasBan = await hasFAGCBans({
+			const FAGCBan = await hasFAGCBans({
 				playername,
 				filter: client.filterObject,
 				database: client.db,
 			})
-			if (hasBan) {
+			if (FAGCBan) {
 				const report = await client.fagc.reports.fetchReport({
-					reportId: hasBan.id,
+					reportId: FAGCBan.id,
 				})
 				const bancmd = client.createBanCommand(report!)
-				if (bancmd) await client.rcon.rconCommandAll(bancmd)
+				if (bancmd) {
+					client.createActionForReport(FAGCBan.playername)
+					await client.rcon.rconCommandAll(bancmd)
+				}
 				return interaction.reply({
-					content: `Player ${playername} was unbanned privately, but was banned due to FAGC report ${hasBan.id}`,
+					content: `Player ${playername} was unbanned privately, but was banned due to FAGC report ${FAGCBan.id}`,
 				})
 			}
 		}

--- a/apps/clientside-bot/src/commands/whitelist/create.ts
+++ b/apps/clientside-bot/src/commands/whitelist/create.ts
@@ -48,7 +48,7 @@ const Setaction: SubCommand = {
 			reason: reason,
 		})
 
-		await client.rcon.rconCommandAll(`/whitelist add ${playername}`)
+		await client.rcon.rconCommandAll(`/unban ${playername}`)
 
 		return interaction.reply({
 			content: `Player ${playername} is now whitelisted for ${reason}`,

--- a/apps/clientside-bot/src/commands/whitelist/create.ts
+++ b/apps/clientside-bot/src/commands/whitelist/create.ts
@@ -48,6 +48,7 @@ const Setaction: SubCommand = {
 			reason: reason,
 		})
 
+		client.createActionForUnban(playername)
 		await client.rcon.rconCommandAll(`/unban ${playername}`)
 
 		return interaction.reply({

--- a/apps/clientside-bot/src/commands/whitelist/remove.ts
+++ b/apps/clientside-bot/src/commands/whitelist/remove.ts
@@ -39,8 +39,6 @@ const Setaction: SubCommand = {
 				ephemeral: true,
 			})
 
-		await client.rcon.rconCommandAll(`/whitelist remove ${playername}`)
-
 		if (client.filterObject) {
 			const hasBan = await hasFAGCBans({
 				playername,

--- a/apps/clientside-bot/src/commands/whitelist/remove.ts
+++ b/apps/clientside-bot/src/commands/whitelist/remove.ts
@@ -40,19 +40,22 @@ const Setaction: SubCommand = {
 			})
 
 		if (client.filterObject) {
-			const hasBan = await hasFAGCBans({
+			const FAGCBan = await hasFAGCBans({
 				playername,
 				filter: client.filterObject,
 				database: client.db,
 			})
-			if (hasBan) {
+			if (FAGCBan) {
 				const report = await client.fagc.reports.fetchReport({
-					reportId: hasBan.id,
+					reportId: FAGCBan.id,
 				})
 				const bancmd = client.createBanCommand(report!)
-				if (bancmd) await client.rcon.rconCommandAll(bancmd)
+				if (bancmd) {
+					client.createActionForReport(FAGCBan.playername)
+					await client.rcon.rconCommandAll(bancmd)
+				}
 				return interaction.reply({
-					content: `Player ${playername} was unwhitelisted, but was banned due to FAGC report ${hasBan.id}`,
+					content: `Player ${playername} was unwhitelisted, but was banned due to FAGC report ${FAGCBan.id}`,
 				})
 			}
 		}


### PR DESCRIPTION
Create actions for FAGC bans, so that the /ban or /unban command is not sent twice.

Also disable use of the /whitelist command, as that allows only the people that are on the whitelist to join the game. Instead use the whitelist provided by the clientside bot, which makes the people on the list immune to FAGC reports.

Resolves #145 