### PR TITLE
feat(revocations): disable auth for fetch by id

### DIFF
--- a/apps/backend/src/routes/revocations.controller.ts
+++ b/apps/backend/src/routes/revocations.controller.ts
@@ -105,7 +105,7 @@ export default class RevocationController {
 					id: z.string(),
 				}),
 
-				description: "Fetch revocation",
+				description: "Fetch revocation by ID",
 				tags: ["revocations"],
 				security: [
 					{
@@ -118,7 +118,6 @@ export default class RevocationController {
 			},
 		},
 	})
-	@Authenticate
 	async fetch(
 		req: FastifyRequest<{
 			Params: {
@@ -128,20 +127,12 @@ export default class RevocationController {
 		res: FastifyReply
 	): Promise<FastifyReply> {
 		const { id } = req.params
-		const { community } = req.requestContext.get("auth")
-		if (!community)
-			return res.status(404).send({
-				errorCode: 404,
-				error: "Community not found",
-				message: "Community not found",
-			})
 
 		const revocation = await ReportInfoModel.findOne({
 			id: id,
 		})
 		if (!revocation) return res.send(null)
 		if (!revocation.revokedAt) return res.send(null) // it is a report as it has not been revoked
-		if (revocation.communityId !== community.id) return res.send(null)
 
 		return res.send(revocation)
 	}

--- a/packages/wrapper/src/managers/RevocationManager.ts
+++ b/packages/wrapper/src/managers/RevocationManager.ts
@@ -61,17 +61,10 @@ export default class RevocationManager extends BaseManager<Revocation> {
 	async fetchRevocation({
 		revocationId,
 		cache = true,
-		reqConfig = {},
 	}: {
 		revocationId: string
 	} & FetchRequestTypes): Promise<Revocation | null> {
-		const req = await fetch(`${this.apiurl}/revocations/${revocationId}`, {
-			credentials: "include",
-			headers: {
-				authorization: authenticate(this, reqConfig),
-			},
-		})
-		if (req.status === 401) throw new AuthError()
+		const req = await fetch(`${this.apiurl}/revocations/${revocationId}`)
 		const revocation = await req.json()
 
 		if (!revocation) return null


### PR DESCRIPTION
- Created a `POST /revocations/bulk` method, which can check which reports were revoked since a timestamp by providing the report IDs the client knows about.
- Modified `GET /revocations/:id` to not require authentication, as the client already knows about the report

Resolves #155