### PR TITLE
fix(clientside): disable error on no subcommand

### DIFF
--- a/apps/clientside-bot/src/base/Commands.ts
+++ b/apps/clientside-bot/src/base/Commands.ts
@@ -54,7 +54,7 @@ export function executeCommandInteraction(
 	commands: (SubCommand | SubCommandGroup)[]
 ) {
 	const subcommand = args.interaction.options.getSubcommand()
-	const group = args.interaction.options.getSubcommandGroup(true)
+	const group = args.interaction.options.getSubcommandGroup(false)
 	const command = commands.find(
 		(command) =>
 			command.data.name === subcommand || command.data.name === group

--- a/apps/clientside-bot/src/base/wshandler.ts
+++ b/apps/clientside-bot/src/base/wshandler.ts
@@ -6,12 +6,10 @@ import {
 	TextChannel,
 	ThreadChannel,
 } from "discord.js"
-import {
-	filterObjectChangedBanlists,
-	handleReport,
-	handleRevocation,
-	splitIntoGroups,
-} from "../utils/functions"
+import filterObjectChangedBanlists from "../utils/functions/filterObjectChangedBanlists"
+import handleReport from "../utils/functions/handleReport"
+import handleRevocation from "../utils/functions/handleRevocation"
+import splitIntoGroups from "../utils/functions/splitIntoGroups"
 import ENV from "../utils/env"
 import FAGCBan from "../database/FAGCBan"
 


### PR DESCRIPTION
In the executeCommandInteraction function, disable throwing errors if no subcommand group was found. Resolves #172 